### PR TITLE
Add getIntBuffer() to ImmutableConciseSet

### DIFF
--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
@@ -733,6 +733,10 @@ public class ImmutableConciseSet
     this.size = calcSize();
   }
 
+  public IntBuffer toIntBuffer(){
+    return words.asReadOnlyBuffer();
+  }
+
   public byte[] toBytes()
   {
     if (words == null) {


### PR DESCRIPTION
This way copying data does not necessarily require a heap backed byte array.
