### PR TITLE
Add ImmutableConciseSet.contains

### DIFF
--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
@@ -822,6 +822,21 @@ public class ImmutableConciseSet
     return last;
   }
 
+  public boolean contains(final int i)
+  {
+    final IntSet.IntIterator intIterator = iterator();
+    while (intIterator.hasNext()) {
+      final int j = intIterator.next();
+      if (i == j) {
+        return true;
+      }
+      if (j > i) {
+        break;
+      }
+    }
+    return false;
+  }
+
   // Based on the ConciseSet implementation by Alessandro Colantonio
   public int get(int i)
   {

--- a/src/test/java/it.uniroma3.mat.extendedset/intset/ImmutableConciseSetTest.java
+++ b/src/test/java/it.uniroma3.mat.extendedset/intset/ImmutableConciseSetTest.java
@@ -23,10 +23,11 @@ import org.junit.Test;
 import java.nio.IntBuffer;
 import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.Collections;
+import java.util.HashSet;
 import java.util.List;
 import java.util.NoSuchElementException;
 import java.util.Random;
+import java.util.Set;
 
 /**
  */
@@ -1944,5 +1945,28 @@ public class ImmutableConciseSetTest
       actual.add(itr.next());
     }
     Assert.assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testContains()
+  {
+    final ConciseSet conciseSet = new ConciseSet();
+    final Random random = new Random(543167436715430L);
+    final Set<Integer> integerSet = new HashSet<>();
+    int max = -1;
+    for (int i = 0; i < 100; ++i) {
+      final int j = random.nextInt(1 << 20);
+      integerSet.add(j);
+      conciseSet.add(j);
+      if (j > max) {
+        max = j;
+      }
+    }
+    final ImmutableConciseSet immutableConciseSet = ImmutableConciseSet.newImmutableFromMutable(conciseSet);
+    for (int i = 0; i < max + 10; ++i) {
+      final String s = Integer.toString(i);
+      Assert.assertEquals(s, integerSet.contains(i), conciseSet.contains(i));
+      Assert.assertEquals(s, integerSet.contains(i), immutableConciseSet.contains(i));
+    }
   }
 }


### PR DESCRIPTION
Add a `contains` method to `ImmutableConciseSet`.

A cheap way to do the checking. A more efficient way would be to use words directly, but it.uniroma3.mat.extendedset.intset.ImmutableConciseSet#doIntersection is very complicated in how it walks.