### PR TITLE
Add ImmutableconciseSetBenchmark

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -68,7 +68,13 @@
         <dependency>
             <groupId>junit</groupId>
             <artifactId>junit</artifactId>
-            <version>4.8.1</version>
+            <version>4.12</version>
+            <scope>test</scope>
+        </dependency>
+        <dependency>
+            <groupId>com.carrotsearch</groupId>
+            <artifactId>junit-benchmarks</artifactId>
+            <version>0.7.2</version>
             <scope>test</scope>
         </dependency>
     </dependencies>
@@ -89,4 +95,23 @@
             </plugin>
         </plugins>
     </build>
+
+    <profiles>
+        <profile>
+            <id>benchmark</id>
+            <build>
+                <plugins>
+                    <plugin>
+                        <artifactId>maven-surefire-plugin</artifactId>
+                        <configuration>
+                            <argLine>-server -Xms3G -Xmx3G -Djub.consumers=CONSOLE</argLine>
+                                <includes>
+                                    <include>**/BenchmarkSuite.class</include>
+                                </includes>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+    </profiles>
 </project>

--- a/src/test/java/it.uniroma3.mat.extendedset/intset/ImmutableconciseSetBenchmark.java
+++ b/src/test/java/it.uniroma3.mat.extendedset/intset/ImmutableconciseSetBenchmark.java
@@ -1,0 +1,89 @@
+/*
+ * Copyright 2016 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package it.uniroma3.mat.extendedset.intset;
+
+import com.carrotsearch.junitbenchmarks.BenchmarkOptions;
+import com.carrotsearch.junitbenchmarks.BenchmarkRule;
+import com.carrotsearch.junitbenchmarks.Clock;
+import com.carrotsearch.junitbenchmarks.annotation.BenchmarkHistoryChart;
+import com.carrotsearch.junitbenchmarks.annotation.LabelType;
+import it.uniroma3.mat.extendedset.test.Benchmark;
+import org.junit.Assert;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.experimental.categories.Category;
+import org.junit.rules.TestRule;
+
+import java.util.HashSet;
+import java.util.Random;
+import java.util.Set;
+
+@Category({Benchmark.class})
+@BenchmarkHistoryChart(labelWith = LabelType.CUSTOM_KEY, maxRuns = 20)
+@BenchmarkOptions(clock = Clock.NANO_TIME, benchmarkRounds = 10)
+public class ImmutableConciseSetBenchmark
+{
+  private static final long SEED = 34731478387914L;
+  private static final int NUM_INTS = 17165;
+  private static final int INT_LIMIT_MAX = ConciseSetUtils.MAX_ALLOWED_INTEGER;
+  private static final Set<Integer> INTS = new HashSet<>(NUM_INTS);
+  private static ImmutableConciseSet immutableConciseSet;
+
+  @Rule
+  public TestRule benchmarkRun = new BenchmarkRule();
+
+  @BeforeClass
+  public static void setUp() throws Exception
+  {
+    final Random random = new Random(SEED);
+
+    final ConciseSet conciseSet = new ConciseSet();
+    for (int i = 0; i < NUM_INTS; ++i) {
+
+      int j;
+      do {
+        j = random.nextInt(INT_LIMIT_MAX);
+      } while (!INTS.add(j));
+      conciseSet.add(j);
+    }
+    immutableConciseSet = ImmutableConciseSet.newImmutableFromMutable(conciseSet);
+  }
+
+  @Test
+  @BenchmarkOptions(warmupRounds = 10, benchmarkRounds = 20)
+  public void timeContains() throws Exception
+  {
+    for (int i : INTS) {
+      Assert.assertEquals(INTS.contains(i), immutableConciseSet.contains(i));
+    }
+  }
+
+  @Test
+  @BenchmarkOptions(warmupRounds = 10, benchmarkRounds = 20)
+  public void timeUnion() throws Exception
+  {
+    for (int i : INTS) {
+      final ConciseSet conciseSet = new ConciseSet();
+      conciseSet.add(i);
+      final ImmutableConciseSet otherSet = ImmutableConciseSet.newImmutableFromMutable(conciseSet);
+      Assert.assertEquals(
+          INTS.contains(i),
+          ImmutableConciseSet.intersection(otherSet, immutableConciseSet).size() != 0
+      );
+    }
+  }
+}

--- a/src/test/java/it.uniroma3.mat.extendedset/test/Benchmark.java
+++ b/src/test/java/it.uniroma3.mat.extendedset/test/Benchmark.java
@@ -1,0 +1,20 @@
+/*
+ * Copyright 2016 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package it.uniroma3.mat.extendedset.test;
+
+public interface Benchmark
+{
+}

--- a/src/test/java/it.uniroma3.mat.extendedset/test/BenchmarkSuite.java
+++ b/src/test/java/it.uniroma3.mat.extendedset/test/BenchmarkSuite.java
@@ -1,0 +1,28 @@
+/*
+ * Copyright 2016 Metamarkets Group Inc.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ *  Unless required by applicable law or agreed to in writing, software
+ *  distributed under the License is distributed on an "AS IS" BASIS,
+ *  WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ *  See the License for the specific language governing permissions and
+ *  limitations under the License.
+ */
+
+package it.uniroma3.mat.extendedset.test;
+
+import it.uniroma3.mat.extendedset.intset.ImmutableConciseSetBenchmark;
+import org.junit.experimental.categories.Categories;
+import org.junit.runner.RunWith;
+import org.junit.runners.Suite;
+
+@RunWith(Categories.class)
+@Categories.IncludeCategory(Benchmark.class)
+@Suite.SuiteClasses({ImmutableConciseSetBenchmark.class})
+public class BenchmarkSuite
+{
+}


### PR DESCRIPTION
- Runs with `mvn clean test -Pbenchmark`

Results:

```
ImmutableConciseSetBenchmark.timeContains: [measured 20 out of 30 rounds, threads: 1 (sequential)]
 round: 1.00 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 0, GC.time: 0.00, time.total: 30.04, time.warmup: 10.00, time.bench: 20.04
ImmutableConciseSetBenchmark.timeUnion: [measured 20 out of 30 rounds, threads: 1 (sequential)]
 round: 0.63 [+- 0.01], round.block: 0.00 [+- 0.00], round.gc: 0.00 [+- 0.00], GC.calls: 2, GC.time: 0.00, time.total: 19.19, time.warmup: 6.55, time.bench: 12.64
```
