### PR TITLE
Concise intersection union optimizations

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -63,6 +63,11 @@
             <artifactId>guava</artifactId>
             <version>16.0.1</version>
         </dependency>
+        <dependency>
+            <groupId>org.roaringbitmap</groupId>
+            <artifactId>RoaringBitmap</artifactId>
+            <version>0.5.18</version>
+        </dependency>
 
         <!-- Tests -->
         <dependency>

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSet.java
@@ -390,7 +390,7 @@ public class ConciseSet extends AbstractIntSet implements java.io.Serializable
    */
   private static int getLiteralBitCount(int word)
   {
-    return BitCount.count(getLiteralBits(word));
+    return Integer.bitCount(getLiteralBits(word));
   }
 
   /**
@@ -1395,7 +1395,7 @@ public class ConciseSet extends AbstractIntSet implements java.io.Serializable
           if ((w & (1 << bitPosition)) == 0) {
             return -1;
           }
-          return index + BitCount.count(w & ~(0xFFFFFFFF << bitPosition));
+          return index + Integer.bitCount(w & ~(0xFFFFFFFF << bitPosition));
         }
         blockIndex--;
         index += getLiteralBitCount(w);
@@ -1412,7 +1412,7 @@ public class ConciseSet extends AbstractIntSet implements java.io.Serializable
             if ((l & (1 << bitPosition)) == 0) {
               return -1;
             }
-            return index + BitCount.count(l & ~(0xFFFFFFFF << bitPosition));
+            return index + Integer.bitCount(l & ~(0xFFFFFFFF << bitPosition));
           }
 
           // if we are in the middle of a sequence of 1's, the bit already exist

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
@@ -296,7 +296,7 @@ public class ConciseSetUtils
    */
   public static int getLiteralBitCount(int word)
   {
-    return BitCount.count(getLiteralBits(word));
+    return Integer.bitCount(getLiteralBits(word));
   }
 
   /**

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
@@ -284,7 +284,7 @@ public class ConciseSetUtils
 
   public static int flipBitAsBinaryString(int flipBit)
   {
-    return ((Number) Math.pow(2, flipBit)).intValue();
+    return 1 << flipBit;
   }
 
   /**

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
@@ -108,7 +108,7 @@ public class ConciseSetUtils
    */
   public static int maxLiteralLengthMultiplication(int n)
   {
-    return (n << 5) - n;
+    return n * 31;
   }
 
   /**
@@ -132,9 +132,8 @@ public class ConciseSetUtils
    */
   public static boolean isLiteral(int word)
   {
-    // "word" must be 1*
-    // NOTE: this is faster than "return (word & 0x80000000) == 0x80000000"
-    return (word & 0x80000000) != 0;
+    // the highest one bit should be 1, which means the word as a number is negative
+    return word < 0;
   }
 
   /**
@@ -313,17 +312,17 @@ public class ConciseSetUtils
 
   public static boolean isAllOnesLiteral(int word)
   {
-    return (word & -1) == -1;
+    return word == -1;
   }
 
   public static boolean isAllZerosLiteral(int word)
   {
-    return (word | 0x80000000) == 0x80000000;
+    return word == 0x80000000;
   }
 
   public static boolean isLiteralWithSingleZeroBit(int word)
   {
-    return isLiteral(word) && (Integer.bitCount(~word) == 1);
+    return isLiteral(word) && Integer.bitCount(word) == 31;
   }
 
   public static boolean isLiteralWithSingleOneBit(int word)

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
@@ -423,27 +423,35 @@ public class ConciseSetUtils
     public void reset(int offset, int word, boolean fromBeginning)
     {
       if (isLiteral(word)) {
-        len = 0;
-        for (int i = 0; i < MAX_LITERAL_LENGTH; i++) {
-          if ((word & (1 << i)) != 0) {
-            buffer[len++] = offset + i;
-          }
-        }
-        current = fromBeginning ? 0 : len;
+        resetLiteral(offset, word, fromBeginning);
+      } else if (isZeroSequence(word)) {
+        resetZeroSequence(offset, word, fromBeginning);
       } else {
-        if (isZeroSequence(word)) {
-          if (isSequenceWithNoBits(word)) {
-            len = 0;
-            current = 0;
-          } else {
-            len = 1;
-            buffer[0] = offset + ((0x3FFFFFFF & word) >>> 25) - 1;
-            current = fromBeginning ? 0 : 1;
-          }
-        } else {
-          throw new RuntimeException("sequence of ones!");
+        throw new RuntimeException("sequence of ones!");
+      }
+    }
+
+    private void resetZeroSequence(int offset, int word, boolean fromBeginning)
+    {
+      if (isSequenceWithNoBits(word)) {
+        len = 0;
+        current = 0;
+      } else {
+        len = 1;
+        buffer[0] = offset + ((0x3FFFFFFF & word) >>> 25) - 1;
+        current = fromBeginning ? 0 : 1;
+      }
+    }
+
+    private void resetLiteral(int offset, int word, boolean fromBeginning)
+    {
+      len = 0;
+      for (int i = 0; i < MAX_LITERAL_LENGTH; i++) {
+        if ((word & (1 << i)) != 0) {
+          buffer[len++] = offset + i;
         }
       }
+      current = fromBeginning ? 0 : len;
     }
 
     @Override

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSetUtils.java
@@ -317,7 +317,9 @@ public class ConciseSetUtils
 
   public static boolean isAllZerosLiteral(int word)
   {
-    return word == 0x80000000;
+    // Either 0x80000000 ("all zeros literal" as it is) or 0, that is "zero sequence of 1 block" = 31 bits,
+    // i. e. semantically equivalent to "all zeros literal".
+    return (word & ALL_ONES_WITHOUT_MSB) == 0;
   }
 
   public static boolean isLiteralWithSingleZeroBit(int word)

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/FastSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/FastSet.java
@@ -487,7 +487,7 @@ public class FastSet extends AbstractIntSet implements java.io.Serializable
 
     int count = 0;
     for (int i = Math.min(firstEmptyWord, other.firstEmptyWord) - 1; i >= 0; i--) {
-      count += BitCount.count(localWords[i] & localOtherWords[i]);
+      count += Integer.bitCount(localWords[i] & localOtherWords[i]);
       if (count >= minElements) {
         return true;
       }
@@ -542,7 +542,7 @@ public class FastSet extends AbstractIntSet implements java.io.Serializable
 
     int count = 0;
     for (int i = Math.min(firstEmptyWord, other.firstEmptyWord) - 1; i >= 0; i--) {
-      count += BitCount.count(localWords[i] & localOtherWords[i]);
+      count += Integer.bitCount(localWords[i] & localOtherWords[i]);
     }
     return count;
   }
@@ -1134,7 +1134,7 @@ public class FastSet extends AbstractIntSet implements java.io.Serializable
     final int[] localWords = words;       // faster
     for (int j = 0; j < firstEmptyWord; j++) {
       int w = localWords[j];
-      int current = BitCount.count(w);
+      int current = Integer.bitCount(w);
       if (index < count + current) {
         int bit = -1;
         for (int skip = index - count; skip >= 0; skip--) {
@@ -1165,7 +1165,7 @@ public class FastSet extends AbstractIntSet implements java.io.Serializable
       return -1;
     }
     int count = BitCount.count(words, index);
-    count += BitCount.count(words[index] & ~(ALL_ONES_WORD << e));
+    count += Integer.bitCount(words[index] & ~(ALL_ONES_WORD << e));
     return count;
 
   }

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
@@ -1061,7 +1061,7 @@ public class ImmutableConciseSet
     }
   }
 
-  public class WordIterator implements Iterator
+  public class WordIterator implements org.roaringbitmap.IntIterator, Cloneable
   {
     private int startIndex;
     private int wordsWalked;
@@ -1105,12 +1105,12 @@ public class ImmutableConciseSet
     }
 
     @Override
-    public Integer next()
+    public int next()
     {
       if (hasNextWord) {
         currWord = nextWord;
         hasNextWord = false;
-        return new Integer(currWord);
+        return currWord;
       }
 
       currWord = words.get(++currRow);
@@ -1121,13 +1121,17 @@ public class ImmutableConciseSet
         wordsWalked += ConciseSetUtils.getSequenceNumWords(currWord);
       }
 
-      return new Integer(currWord);
+      return currWord;
     }
 
     @Override
-    public void remove()
-    {
-      throw new UnsupportedOperationException();
+    public WordIterator clone() {
+      try {
+        return (WordIterator) super.clone();
+      }
+      catch (CloneNotSupportedException e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
@@ -51,12 +51,13 @@ public class ImmutableConciseSet
       int s2 = h2.getIterator().startIndex;
 
       if (s1 != s2) {
-        return compareInts(s1, s2);
+        return Integer.compare(s1, s2);
       }
 
       if (ConciseSetUtils.isOneSequence(w1)) {
         if (ConciseSetUtils.isOneSequence(w2)) {
-          return -compareInts(ConciseSetUtils.getSequenceNumWords(w1), ConciseSetUtils.getSequenceNumWords(w2));
+          // reverse
+          return Integer.compare(ConciseSetUtils.getSequenceNumWords(w2), ConciseSetUtils.getSequenceNumWords(w1));
         }
         return -1;
       } else if (ConciseSetUtils.isLiteral(w1)) {
@@ -70,7 +71,7 @@ public class ImmutableConciseSet
         if (!ConciseSetUtils.isZeroSequence(w2)) {
           return 1;
         }
-        return compareInts(ConciseSetUtils.getSequenceNumWords(w1), ConciseSetUtils.getSequenceNumWords(w2));
+        return Integer.compare(ConciseSetUtils.getSequenceNumWords(w1), ConciseSetUtils.getSequenceNumWords(w2));
       }
     }
   };
@@ -90,12 +91,13 @@ public class ImmutableConciseSet
       int s2 = h2.getIterator().startIndex;
 
       if (s1 != s2) {
-        return compareInts(s1, s2);
+        return Integer.compare(s1, s2);
       }
 
       if (ConciseSetUtils.isZeroSequence(w1)) {
         if (ConciseSetUtils.isZeroSequence(w2)) {
-          return -compareInts(ConciseSetUtils.getSequenceNumWords(w1), ConciseSetUtils.getSequenceNumWords(w2));
+          // reverse
+          return Integer.compare(ConciseSetUtils.getSequenceNumWords(w2), ConciseSetUtils.getSequenceNumWords(w1));
         }
         return -1;
       } else if (ConciseSetUtils.isLiteral(w1)) {
@@ -109,7 +111,7 @@ public class ImmutableConciseSet
         if (!ConciseSetUtils.isOneSequence(w2)) {
           return 1;
         }
-        return compareInts(ConciseSetUtils.getSequenceNumWords(w1), ConciseSetUtils.getSequenceNumWords(w2));
+        return Integer.compare(ConciseSetUtils.getSequenceNumWords(w1), ConciseSetUtils.getSequenceNumWords(w2));
       }
     }
   };
@@ -120,11 +122,6 @@ public class ImmutableConciseSet
       return new ImmutableConciseSet();
     }
     return new ImmutableConciseSet(IntBuffer.wrap(conciseSet.getWords()));
-  }
-
-  public static int compareInts(int x, int y)
-  {
-    return (x < y) ? -1 : ((x == y) ? 0 : 1);
   }
 
   public static ImmutableConciseSet union(ImmutableConciseSet... sets)

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
@@ -18,14 +18,13 @@ package it.uniroma3.mat.extendedset.intset;
 
 
 import com.google.common.collect.Iterators;
-import com.google.common.collect.Lists;
-import com.google.common.collect.MinMaxPriorityQueue;
 import com.google.common.collect.UnmodifiableIterator;
 import com.google.common.primitives.Ints;
 import it.uniroma3.mat.extendedset.utilities.IntList;
 
 import java.nio.ByteBuffer;
 import java.nio.IntBuffer;
+import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -36,23 +35,24 @@ public class ImmutableConciseSet
 {
   private final static int CHUNK_SIZE = 10000;
 
-  private static final Comparator<WordHolder> UNION_COMPARATOR = new Comparator<WordHolder>()
+  private static final Comparator<WordIterator> UNION_COMPARATOR = new Comparator<WordIterator>()
   {
     // lhs = current word position, rhs = the iterator
     // Comparison is first by index, then one fills > literals > zero fills
     // one fills are sorted by length (longer one fills have priority)
     // similarily, shorter zero fills have priority
     @Override
-    public int compare(WordHolder h1, WordHolder h2)
+    public int compare(WordIterator i1, WordIterator i2)
     {
-      int w1 = h1.getWord();
-      int w2 = h2.getWord();
-      int s1 = h1.getIterator().startIndex;
-      int s2 = h2.getIterator().startIndex;
+      int s1 = i1.startIndex;
+      int s2 = i2.startIndex;
 
       if (s1 != s2) {
         return Integer.compare(s1, s2);
       }
+
+      int w1 = i1.getWord();
+      int w2 = i2.getWord();
 
       if (ConciseSetUtils.isOneSequence(w1)) {
         if (ConciseSetUtils.isOneSequence(w2)) {
@@ -76,23 +76,24 @@ public class ImmutableConciseSet
     }
   };
 
-  private static final Comparator<WordHolder> INTERSECTION_COMPARATOR = new Comparator<WordHolder>()
+  private static final Comparator<WordIterator> INTERSECTION_COMPARATOR = new Comparator<WordIterator>()
   {
     // lhs = current word position, rhs = the iterator
     // Comparison is first by index, then zero fills > literals > one fills
     // zero fills are sorted by length (longer zero fills have priority)
     // similarily, shorter one fills have priority
     @Override
-    public int compare(WordHolder h1, WordHolder h2)
+    public int compare(WordIterator i1, WordIterator i2)
     {
-      int w1 = h1.getWord();
-      int w2 = h2.getWord();
-      int s1 = h1.getIterator().startIndex;
-      int s2 = h2.getIterator().startIndex;
+      int s1 = i1.startIndex;
+      int s2 = i2.startIndex;
 
       if (s1 != s2) {
         return Integer.compare(s1, s2);
       }
+
+      int w1 = i1.getWord();
+      int w2 = i2.getWord();
 
       if (ConciseSetUtils.isZeroSequence(w1)) {
         if (ConciseSetUtils.isZeroSequence(w2)) {
@@ -331,8 +332,7 @@ public class ImmutableConciseSet
   private static ImmutableConciseSet doUnion(Iterator<ImmutableConciseSet> sets)
   {
     IntList retVal = new IntList();
-
-    MinMaxPriorityQueue<WordHolder> theQ = MinMaxPriorityQueue.orderedBy(UNION_COMPARATOR).create();
+    List<WordIterator> iterators = new ArrayList<>();
 
     // populate priority queue
     while (sets.hasNext()) {
@@ -340,20 +340,23 @@ public class ImmutableConciseSet
 
       if (set != null && !set.isEmpty()) {
         WordIterator itr = set.newWordIterator();
-        theQ.add(new WordHolder(itr.next(), itr));
+        itr.word = itr.next();
+        iterators.add(itr);
       }
     }
 
+
+    WordIterator[] theQ = iterators.toArray(new WordIterator[0]);
+    sort(theQ, theQ.length, UNION_COMPARATOR);
+    int qSize = theQ.length;
+
     int currIndex = 0;
 
-    while (!theQ.isEmpty()) {
-      // create a temp list to hold everything that will get pushed back into the priority queue after each run
-      List<WordHolder> wordsToAdd = Lists.newArrayList();
+    while (qSize > 0) {
 
       // grab the top element from the priority queue
-      WordHolder curr = theQ.poll();
-      int word = curr.getWord();
-      WordIterator itr = curr.getIterator();
+      WordIterator itr = theQ[0];
+      int word = itr.getWord();
 
       // if the next word in the queue starts at a different point than where we ended off we need to create a zero gap
       // to fill the space
@@ -367,12 +370,11 @@ public class ImmutableConciseSet
         int flipBitLiteral = ConciseSetUtils.getLiteralFromOneSeqFlipBit(word);
 
         // advance everything past the longest ones sequence
-        WordHolder nextVal = theQ.peek();
-        while (nextVal != null &&
-               nextVal.getIterator().startIndex < itr.wordsWalked) {
-          WordHolder entry = theQ.poll();
-          int w = entry.getWord();
-          WordIterator i = entry.getIterator();
+        int qIndex = 1;
+        while (qIndex < qSize &&
+               theQ[qIndex].startIndex < itr.wordsWalked) {
+          WordIterator i = theQ[qIndex];
+          int w = i.getWord();
 
           if (i.startIndex == itr.startIndex) {
             // if a literal was created from a flip bit, OR it with other literals or literals from flip bits in the same
@@ -388,9 +390,12 @@ public class ImmutableConciseSet
 
           i.advanceTo(itr.wordsWalked);
           if (i.hasNext()) {
-            wordsToAdd.add(new WordHolder(i.next(), i));
+            i.word = i.next();
+            qIndex++;
+          } else {
+            removeElement(theQ, qIndex, qSize);
+            qSize--;
           }
-          nextVal = theQ.peek();
         }
 
         // advance longest one literal forward and push result back to priority queue
@@ -405,17 +410,19 @@ public class ImmutableConciseSet
         currIndex = itr.wordsWalked;
 
         if (itr.hasNext()) {
-          wordsToAdd.add(new WordHolder(itr.next(), itr));
+          itr.word = itr.next();
+        } else {
+          removeElement(theQ, 0, qSize);
+          qSize--;
         }
       } else if (ConciseSetUtils.isLiteral(word)) {
         // advance all other literals
-        WordHolder nextVal = theQ.peek();
-        while (nextVal != null &&
-               nextVal.getIterator().startIndex == itr.startIndex) {
+        int qIndex = 1;
+        while (qIndex < qSize &&
+               theQ[qIndex].startIndex == itr.startIndex) {
 
-          WordHolder entry = theQ.poll();
-          int w = entry.getWord();
-          WordIterator i = entry.getIterator();
+          WordIterator i = theQ[qIndex];
+          int w = i.getWord();
 
           // if we still have zero fills with flipped bits, OR them here
           if (ConciseSetUtils.isLiteral(w)) {
@@ -429,10 +436,12 @@ public class ImmutableConciseSet
           }
 
           if (i.hasNext()) {
-            wordsToAdd.add(new WordHolder(i.next(), i));
+            i.word = i.next();
+            qIndex++;
+          } else {
+            removeElement(theQ, qIndex, qSize);
+            qSize--;
           }
-
-          nextVal = theQ.peek();
         }
 
         // advance the set with the current literal forward and push result back to priority queue
@@ -440,38 +449,46 @@ public class ImmutableConciseSet
         currIndex++;
 
         if (itr.hasNext()) {
-          wordsToAdd.add(new WordHolder(itr.next(), itr));
+          itr.word = itr.next();
+        } else {
+          removeElement(theQ, 0, qSize);
+          qSize--;
         }
       } else { // zero fills
         int flipBitLiteral;
-        WordHolder nextVal = theQ.peek();
-
-        while (nextVal != null &&
-               nextVal.getIterator().startIndex == itr.startIndex) {
+        int qIndex = 1;
+        while (qIndex < qSize &&
+               theQ[qIndex].startIndex == itr.startIndex) {
           // check if literal can be created flip bits of other zero sequences
-          WordHolder entry = theQ.poll();
-          int w = entry.getWord();
-          WordIterator i = entry.getIterator();
+          WordIterator i = theQ[qIndex];
+          int w = i.getWord();
 
           flipBitLiteral = ConciseSetUtils.getLiteralFromZeroSeqFlipBit(w);
           if (flipBitLiteral != ConciseSetUtils.ALL_ZEROS_LITERAL) {
-            wordsToAdd.add(new WordHolder(flipBitLiteral, i));
+            i.word = flipBitLiteral;
+            qIndex++;
           } else if (i.hasNext()) {
-            wordsToAdd.add(new WordHolder(i.next(), i));
+            i.word = i.next();
+            qIndex++;
+          } else {
+            removeElement(theQ, qIndex, qSize);
+            qSize--;
           }
-          nextVal = theQ.peek();
         }
 
         // check if a literal needs to be created from the flipped bits of this sequence
         flipBitLiteral = ConciseSetUtils.getLiteralFromZeroSeqFlipBit(word);
         if (flipBitLiteral != ConciseSetUtils.ALL_ZEROS_LITERAL) {
-          wordsToAdd.add(new WordHolder(flipBitLiteral, itr));
+          itr.word = flipBitLiteral;
         } else if (itr.hasNext()) {
-          wordsToAdd.add(new WordHolder(itr.next(), itr));
+          itr.word = itr.next();
+        } else {
+          removeElement(theQ, 0, qSize);
+          qSize--;
         }
       }
 
-      theQ.addAll(wordsToAdd);
+      sort(theQ, qSize, UNION_COMPARATOR);
     }
 
     if (retVal.isEmpty()) {
@@ -484,8 +501,7 @@ public class ImmutableConciseSet
   {
     IntList retVal = new IntList();
 
-    MinMaxPriorityQueue<WordHolder> theQ = MinMaxPriorityQueue.orderedBy(INTERSECTION_COMPARATOR).create();
-
+    ArrayList<WordIterator> iterators = new ArrayList<>();
     // populate priority queue
     while (sets.hasNext()) {
       ImmutableConciseSet set = sets.next();
@@ -495,20 +511,22 @@ public class ImmutableConciseSet
       }
 
       WordIterator itr = set.newWordIterator();
-      theQ.add(new WordHolder(itr.next(), itr));
+      itr.word = itr.next();
+      iterators.add(itr);
     }
+    WordIterator[] theQ = iterators.toArray(new WordIterator[0]);
+    sort(theQ, theQ.length, INTERSECTION_COMPARATOR);
+
+    int qSize = theQ.length;
 
     int currIndex = 0;
     int wordsWalkedAtSequenceEnd = Integer.MAX_VALUE;
 
-    while (!theQ.isEmpty()) {
-      // create a temp list to hold everything that will get pushed back into the priority queue after each run
-      List<WordHolder> wordsToAdd = Lists.newArrayList();
+    while (qSize > 0) {
 
       // grab the top element from the priority queue
-      WordHolder curr = theQ.poll();
-      int word = curr.getWord();
-      WordIterator itr = curr.getIterator();
+      WordIterator itr = theQ[0];
+      int word = itr.getWord();
 
       // if a sequence has ended, we can break out because of Boolean logic
       if (itr.startIndex >= wordsWalkedAtSequenceEnd) {
@@ -528,12 +546,11 @@ public class ImmutableConciseSet
         int flipBitLiteral = ConciseSetUtils.getLiteralFromZeroSeqFlipBit(word);
 
         // advance everything past the longest zero sequence
-        WordHolder nextVal = theQ.peek();
-        while (nextVal != null &&
-               nextVal.getIterator().startIndex < itr.wordsWalked) {
-          WordHolder entry = theQ.poll();
-          int w = entry.getWord();
-          WordIterator i = entry.getIterator();
+        int qIndex = 1;
+        while (qIndex < qSize &&
+               theQ[qIndex].startIndex < itr.wordsWalked) {
+          WordIterator i = theQ[qIndex];
+          int w = i.getWord();
 
           if (i.startIndex == itr.startIndex) {
             // if a literal was created from a flip bit, AND it with other literals or literals from flip bits in the same
@@ -549,11 +566,13 @@ public class ImmutableConciseSet
 
           i.advanceTo(itr.wordsWalked);
           if (i.hasNext()) {
-            wordsToAdd.add(new WordHolder(i.next(), i));
+            i.word = i.next();
+            qIndex++;
           } else {
+            removeElement(theQ, qIndex, qSize);
+            qSize--;
             wordsWalkedAtSequenceEnd = Math.min(i.wordsWalked, wordsWalkedAtSequenceEnd);
           }
-          nextVal = theQ.peek();
         }
 
         // advance longest zero literal forward and push result back to priority queue
@@ -567,19 +586,20 @@ public class ImmutableConciseSet
         currIndex = itr.wordsWalked;
 
         if (itr.hasNext()) {
-          wordsToAdd.add(new WordHolder(itr.next(), itr));
+          itr.word = itr.next();
         } else {
+          removeElement(theQ, 0, qSize);
+          qSize--;
           wordsWalkedAtSequenceEnd = Math.min(itr.wordsWalked, wordsWalkedAtSequenceEnd);
         }
       } else if (ConciseSetUtils.isLiteral(word)) {
         // advance all other literals
-        WordHolder nextVal = theQ.peek();
-        while (nextVal != null &&
-               nextVal.getIterator().startIndex == itr.startIndex) {
+        int qIndex = 1;
+        while (qIndex < qSize &&
+               theQ[qIndex].startIndex == itr.startIndex) {
 
-          WordHolder entry = theQ.poll();
-          int w = entry.getWord();
-          WordIterator i = entry.getIterator();
+          WordIterator i = theQ[qIndex];
+          int w = i.getWord();
 
           // if we still have one fills with flipped bits, AND them here
           if (ConciseSetUtils.isLiteral(w)) {
@@ -593,12 +613,13 @@ public class ImmutableConciseSet
           }
 
           if (i.hasNext()) {
-            wordsToAdd.add(new WordHolder(i.next(), i));
+            i.word = i.next();
+            qIndex++;
           } else {
+            removeElement(theQ, qIndex, qSize);
+            qSize--;
             wordsWalkedAtSequenceEnd = Math.min(i.wordsWalked, wordsWalkedAtSequenceEnd);
           }
-
-          nextVal = theQ.peek();
         }
 
         // advance the set with the current literal forward and push result back to priority queue
@@ -606,45 +627,49 @@ public class ImmutableConciseSet
         currIndex++;
 
         if (itr.hasNext()) {
-          wordsToAdd.add(new WordHolder(itr.next(), itr));
+          itr.word = itr.next();
         } else {
+          removeElement(theQ, 0, qSize);
+          qSize--;
           wordsWalkedAtSequenceEnd = Math.min(itr.wordsWalked, wordsWalkedAtSequenceEnd);
         }
       } else { // one fills
         int flipBitLiteral;
-        WordHolder nextVal = theQ.peek();
-
-        while (nextVal != null &&
-               nextVal.getIterator().startIndex == itr.startIndex) {
+        int qIndex = 1;
+        while (qIndex < qSize &&
+               theQ[qIndex].startIndex == itr.startIndex) {
           // check if literal can be created flip bits of other one sequences
-          WordHolder entry = theQ.poll();
-          int w = entry.getWord();
-          WordIterator i = entry.getIterator();
+          WordIterator i = theQ[qIndex];
+          int w = i.getWord();
 
           flipBitLiteral = ConciseSetUtils.getLiteralFromOneSeqFlipBit(w);
           if (flipBitLiteral != ConciseSetUtils.ALL_ONES_LITERAL) {
-            wordsToAdd.add(new WordHolder(flipBitLiteral, i));
+            i.word = flipBitLiteral;
+            qIndex++;
           } else if (i.hasNext()) {
-            wordsToAdd.add(new WordHolder(i.next(), i));
+            i.word = i.next();
+            qIndex++;
           } else {
+            removeElement(theQ, qIndex, qSize);
+            qSize--;
             wordsWalkedAtSequenceEnd = Math.min(i.wordsWalked, wordsWalkedAtSequenceEnd);
           }
-
-          nextVal = theQ.peek();
         }
 
         // check if a literal needs to be created from the flipped bits of this sequence
         flipBitLiteral = ConciseSetUtils.getLiteralFromOneSeqFlipBit(word);
         if (flipBitLiteral != ConciseSetUtils.ALL_ONES_LITERAL) {
-          wordsToAdd.add(new WordHolder(flipBitLiteral, itr));
+          itr.word = flipBitLiteral;
         } else if (itr.hasNext()) {
-          wordsToAdd.add(new WordHolder(itr.next(), itr));
+          itr.word = itr.next();
         } else {
+          removeElement(theQ, 0, qSize);
+          qSize--;
           wordsWalkedAtSequenceEnd = Math.min(itr.wordsWalked, wordsWalkedAtSequenceEnd);
         }
       }
 
-      theQ.addAll(wordsToAdd);
+      sort(theQ, qSize, INTERSECTION_COMPARATOR);
     }
 
     // fill in any missing one sequences
@@ -656,6 +681,28 @@ public class ImmutableConciseSet
       return new ImmutableConciseSet();
     }
     return new ImmutableConciseSet(IntBuffer.wrap(retVal.toArray()));
+  }
+
+  private static void sort(final WordIterator[] a, final int to, final Comparator<WordIterator> comp)
+  {
+    // Bubble sort, copied from http://stackoverflow.com/a/16089042/648955
+    // Bubble sort seems to be the most efficient sorting algorithm when the number of elements to sort is very
+    // small (in this case mostly 2-4).
+    for (int i = 0; i < to; i++) {
+      for (int j = 1; j < (to - i); j++) {
+        WordIterator it1 = a[j - 1];
+        WordIterator it2 = a[j];
+        if (comp.compare(it1, it2) > 0) {
+          a[j - 1] = it2;
+          a[j] = it1;
+        }
+      }
+    }
+  }
+
+  private static void removeElement(WordIterator[] q, int qIndex, int qSize)
+  {
+    System.arraycopy(q, qIndex + 1, q, qIndex, qSize - qIndex - 1);
   }
 
   public static ImmutableConciseSet doComplement(ImmutableConciseSet set)
@@ -1066,6 +1113,10 @@ public class ImmutableConciseSet
     private int nextWord;
     private int currRow;
 
+    // Probably this is identical to currWord, or nextWord, or could be derived from one of those fields,
+    // but this is uncertain
+    int word;
+
     private volatile boolean hasNextWord = false;
 
     WordIterator()
@@ -1121,39 +1172,20 @@ public class ImmutableConciseSet
       return currWord;
     }
 
+    int getWord()
+    {
+      return word;
+    }
+
     @Override
-    public WordIterator clone() {
+    public WordIterator clone()
+    {
       try {
         return (WordIterator) super.clone();
       }
       catch (CloneNotSupportedException e) {
         throw new RuntimeException(e);
       }
-    }
-  }
-
-  private static class WordHolder
-  {
-    private final int word;
-    private final WordIterator iterator;
-
-    public WordHolder(
-        int word,
-        WordIterator iterator
-    )
-    {
-      this.word = word;
-      this.iterator = iterator;
-    }
-
-    public int getWord()
-    {
-      return word;
-    }
-
-    public WordIterator getIterator()
-    {
-      return iterator;
     }
   }
 }

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
@@ -388,12 +388,13 @@ public class ImmutableConciseSet
           if (i.startIndex == itr.startIndex) {
             // if a literal was created from a flip bit, OR it with other literals or literals from flip bits in the same
             // position
-            if (ConciseSetUtils.isOneSequence(w)) {
-              flipBitLiteral |= ConciseSetUtils.getLiteralFromOneSeqFlipBit(w);
-            } else if (ConciseSetUtils.isLiteral(w)) {
+            if (ConciseSetUtils.isLiteral(w)) {
               flipBitLiteral |= w;
-            } else {
+            } else if (ConciseSetUtils.isZeroSequence(w)) {
               flipBitLiteral |= ConciseSetUtils.getLiteralFromZeroSeqFlipBit(w);
+            } else {
+              // w is one sequence
+              flipBitLiteral |= ConciseSetUtils.getLiteralFromOneSeqFlipBit(w);
             }
           }
 
@@ -564,11 +565,12 @@ public class ImmutableConciseSet
           if (i.startIndex == itr.startIndex) {
             // if a literal was created from a flip bit, AND it with other literals or literals from flip bits in the same
             // position
-            if (ConciseSetUtils.isZeroSequence(w)) {
-              flipBitLiteral &= ConciseSetUtils.getLiteralFromZeroSeqFlipBit(w);
-            } else if (ConciseSetUtils.isLiteral(w)) {
+            if (ConciseSetUtils.isLiteral(w)) {
               flipBitLiteral &= w;
+            } else if (ConciseSetUtils.isZeroSequence(w)) {
+              flipBitLiteral &= ConciseSetUtils.getLiteralFromZeroSeqFlipBit(w);
             } else {
+              // w is one sequence
               flipBitLiteral &= ConciseSetUtils.getLiteralFromOneSeqFlipBit(w);
             }
           }

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/IntSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/IntSet.java
@@ -236,7 +236,7 @@ public interface IntSet extends Cloneable, Comparable<IntSet> {
 	 * An {@link Iterator}-like interface that allows to "skip" some elements of
 	 * the set
 	 */
-	public interface IntIterator {
+	public interface IntIterator extends org.roaringbitmap.IntIterator {
 		/**
 		 * @return <tt>true</tt> if the iterator has more elements.
 		 */

--- a/src/main/java/it/uniroma3/mat/extendedset/utilities/BitCount.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/utilities/BitCount.java
@@ -32,21 +32,6 @@ import java.util.Random;
  * @version $Id: BitCount.java 157 2011-11-14 14:25:15Z cocciasik $
  */
 public class BitCount {
-	/**
-	 * Population count
-	 * <p>
-	 * It counts a single word
-	 * 
-	 * @param word
-	 *            word to count
-	 * @return population count
-	 */
-	public static int count(int word) {
-		word -= ((word >>> 1) & 0x55555555);
-		word = (word & 0x33333333) + ((word >>> 2) & 0x33333333);
-		word = (word + (word >>> 4)) & 0x0F0F0F0F;
-		return (word * 0x01010101) >>> 24;
-	}
 
 	/**
 	 * Population count
@@ -124,7 +109,7 @@ public class BitCount {
 	private static int popcount_fbsd2(int[] data, int x, int n) {
 		int cnt = 0;
 		for (; x < n; x++)
-			cnt += count(data[x]);
+			cnt += Integer.bitCount(data[x]);
 		return cnt;
 	}
 	
@@ -204,7 +189,7 @@ public class BitCount {
 	private static int popcount_fbsd2_2(int[] data, int x, int n) {
 		int cnt = 0;
 		for (x++; x < n; x += 2)
-			cnt += count(data[x]);
+			cnt += Integer.bitCount(data[x]);
 		return cnt;
 	}
 
@@ -229,7 +214,7 @@ public class BitCount {
 
 			int size1 = 0;
 			for (int j = 0; j < x.length; j++)
-				size1 += count(x[j]);
+				size1 += Integer.bitCount(x[j]);
 			int size2 = count(x);
 
 			if (size1 != size2) {
@@ -237,7 +222,7 @@ public class BitCount {
 				System.out.println("ERRORE!");
 				System.out.println(size1 + ", " + size2);
 				for (int j = 0; j < x.length; j++)
-					System.out.format("x[%d] = %d --> %d\n", j, x[j], count(x[j]));
+					System.out.format("x[%d] = %d --> %d\n", j, x[j], Integer.bitCount(x[j]));
 				return;
 			}
 		}
@@ -252,7 +237,7 @@ public class BitCount {
 
 			int size1 = 0;
 			for (int j = 1; j < x.length; j += 2)
-				size1 += count(x[j]);
+				size1 += Integer.bitCount(x[j]);
 			int size2 = count_2(x);
 
 			if (size1 != size2) {
@@ -260,7 +245,7 @@ public class BitCount {
 				System.out.println("ERRORE!");
 				System.out.println(size1 + ", " + size2);
 				for (int j = 1; j < x.length; j += 2)
-					System.out.format("x[%d] = %d --> %d\n", j, x[j], count(x[j]));
+					System.out.format("x[%d] = %d --> %d\n", j, x[j], Integer.bitCount(x[j]));
 				return;
 			}
 		}
@@ -277,7 +262,7 @@ public class BitCount {
 			@SuppressWarnings("unused")
 			int size = 0;
 			for (int j = 0; j < x.length; j++)
-				size += count(x[j]);
+				size += Integer.bitCount(x[j]);
 		}
 		System.out.println(System.currentTimeMillis() - t);
 
@@ -303,7 +288,7 @@ public class BitCount {
 			@SuppressWarnings("unused")
 			int size = 0;
 			for (int j = 1; j < x.length; j += 2)
-				size += count(x[j]);
+				size += Integer.bitCount(x[j]);
 		}
 		System.out.println(System.currentTimeMillis() - t);
 

--- a/src/main/java/it/uniroma3/mat/extendedset/utilities/IntList.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/utilities/IntList.java
@@ -7,23 +7,11 @@ import java.util.ArrayList;
  */
 public class IntList
 {
+  private static final int ALLOCATION_SIZE = 1024;
+
   private final ArrayList<int[]> baseLists = new ArrayList<int[]>();
 
-  private final int allocateSize;
-
-  private int maxIndex;
-
-  public IntList()
-  {
-    this(1000);
-  }
-
-  public IntList(final int allocateSize)
-  {
-    this.allocateSize = allocateSize;
-
-    maxIndex = -1;
-  }
+  private int maxIndex = -1;
 
   public int length()
   {
@@ -42,7 +30,7 @@ public class IntList
 
   public void set(int index, int value)
   {
-    int subListIndex = index / allocateSize;
+    int subListIndex = index / ALLOCATION_SIZE;
 
     if (subListIndex >= baseLists.size()) {
       for (int i = baseLists.size(); i <= subListIndex; ++i) {
@@ -53,11 +41,11 @@ public class IntList
     int[] baseList = baseLists.get(subListIndex);
 
     if (baseList == null) {
-      baseList = new int[allocateSize];
+      baseList = new int[ALLOCATION_SIZE];
       baseLists.set(subListIndex, baseList);
     }
 
-    baseList[index % allocateSize] = value;
+    baseList[index % ALLOCATION_SIZE] = value;
 
     if (index > maxIndex) {
       maxIndex = index;
@@ -70,14 +58,14 @@ public class IntList
       throw new ArrayIndexOutOfBoundsException(index);
     }
 
-    int subListIndex = index / allocateSize;
+    int subListIndex = index / ALLOCATION_SIZE;
     int[] baseList = baseLists.get(subListIndex);
 
     if (baseList == null) {
       return 0;
     }
 
-    return baseList[index % allocateSize];
+    return baseList[index % ALLOCATION_SIZE];
   }
 
   public int baseListCount()
@@ -95,7 +83,7 @@ public class IntList
     final IntBuffer retVal = IntBuffer.wrap(array);
 
     if (index + 1 == baseListCount()) {
-      retVal.limit(maxIndex - (index * allocateSize));
+      retVal.limit(maxIndex - (index * ALLOCATION_SIZE));
     }
 
     return retVal.asReadOnlyBuffer();

--- a/src/test/java/it.uniroma3.mat.extendedset/intset/ImmutableConciseSetTest.java
+++ b/src/test/java/it.uniroma3.mat.extendedset/intset/ImmutableConciseSetTest.java
@@ -46,7 +46,7 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet iSet = ImmutableConciseSet.newImmutableFromMutable(set);
 
     ImmutableConciseSet.WordIterator itr = iSet.newWordIterator();
-    Assert.assertEquals(new Integer(0x8000003E), itr.next());
+    Assert.assertEquals(0x8000003E, itr.next());
 
     Assert.assertEquals(itr.hasNext(), false);
   }
@@ -62,8 +62,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet iSet = ImmutableConciseSet.newImmutableFromMutable(set);
 
     ImmutableConciseSet.WordIterator itr = iSet.newWordIterator();
-    Assert.assertEquals(new Integer(0x40000C98), itr.next());
-    Assert.assertEquals(new Integer(0x81FFFFFF), itr.next());
+    Assert.assertEquals(0x40000C98, itr.next());
+    Assert.assertEquals(0x81FFFFFF, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -82,8 +82,8 @@ public class ImmutableConciseSetTest
 
     ImmutableConciseSet.WordIterator itr = iSet.newWordIterator();
     itr.advanceTo(50);
-    Assert.assertEquals(new Integer(1073744998), itr.next());
-    Assert.assertEquals(new Integer(0x81FFFFFF), itr.next());
+    Assert.assertEquals(1073744998, itr.next());
+    Assert.assertEquals(0x81FFFFFF, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -102,7 +102,7 @@ public class ImmutableConciseSetTest
 
     ImmutableConciseSet.WordIterator itr = iSet.newWordIterator();
     itr.advanceTo(3225);
-    Assert.assertEquals(new Integer(0x81FFFFFF), itr.next());
+    Assert.assertEquals(0x81FFFFFF, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -115,7 +115,7 @@ public class ImmutableConciseSetTest
 
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x40000001), itr.next());
+    Assert.assertEquals(0x40000001, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -127,7 +127,7 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x40000005), itr.next());
+    Assert.assertEquals(0x40000005, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -139,8 +139,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(-1), itr.next());
-    Assert.assertEquals(new Integer(0x42000004), itr.next());
+    Assert.assertEquals(-1, itr.next());
+    Assert.assertEquals(0x42000004, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -152,7 +152,7 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x40000005), itr.next());
+    Assert.assertEquals(0x40000005, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -164,7 +164,7 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x40000009), itr.next());
+    Assert.assertEquals(0x40000009, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -176,8 +176,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x40000004), itr.next());
-    Assert.assertEquals(new Integer(0x42000004), itr.next());
+    Assert.assertEquals(0x40000004, itr.next());
+    Assert.assertEquals(0x42000004, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -189,8 +189,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x00000001), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x00000001, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -202,8 +202,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x00000005), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x00000005, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -215,9 +215,9 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x80000000), itr.next());
-    Assert.assertEquals(new Integer(0x02000004), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x80000000, itr.next());
+    Assert.assertEquals(0x02000004, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -229,8 +229,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x00000005), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x00000005, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -242,8 +242,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x00000009), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x00000009, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -255,9 +255,9 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x00000004), itr.next());
-    Assert.assertEquals(new Integer(0x02000004), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x00000004, itr.next());
+    Assert.assertEquals(0x02000004, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -269,8 +269,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x02000001), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x02000001, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -282,9 +282,9 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x80000003), itr.next());
-    Assert.assertEquals(new Integer(0x80000000), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x80000003, itr.next());
+    Assert.assertEquals(0x80000000, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -296,8 +296,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x02000005), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x02000005, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -309,9 +309,9 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x80000003), itr.next());
-    Assert.assertEquals(new Integer(0x00000004), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x80000003, itr.next());
+    Assert.assertEquals(0x00000004, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -323,9 +323,9 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x80000001), itr.next());
-    Assert.assertEquals(new Integer(0x02000004), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0x80000001, itr.next());
+    Assert.assertEquals(0x02000004, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -337,7 +337,7 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x42000001), itr.next());
+    Assert.assertEquals(0x42000001, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -349,8 +349,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0xFFFFFFEE), itr.next());
-    Assert.assertEquals(new Integer(-1), itr.next());
+    Assert.assertEquals(0xFFFFFFEE, itr.next());
+    Assert.assertEquals(-1, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -362,7 +362,7 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0x42000005), itr.next());
+    Assert.assertEquals(0x42000005, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -374,8 +374,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0xFFFFFFFC), itr.next());
-    Assert.assertEquals(new Integer(0x40000004), itr.next());
+    Assert.assertEquals(0xFFFFFFFC, itr.next());
+    Assert.assertEquals(0x40000004, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -387,8 +387,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0xFFFFFFFE), itr.next());
-    Assert.assertEquals(new Integer(0x42000004), itr.next());
+    Assert.assertEquals(0xFFFFFFFE, itr.next());
+    Assert.assertEquals(0x42000004, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 
@@ -400,8 +400,8 @@ public class ImmutableConciseSetTest
     ImmutableConciseSet res = ImmutableConciseSet.compact(new ImmutableConciseSet(IntBuffer.wrap(words)));
     ImmutableConciseSet.WordIterator itr = res.newWordIterator();
 
-    Assert.assertEquals(new Integer(0xFFFFFFFE), itr.next());
-    Assert.assertEquals(new Integer(0xFFEFFEFF), itr.next());
+    Assert.assertEquals(0xFFFFFFFE, itr.next());
+    Assert.assertEquals(0xFFEFFEFF, itr.next());
     Assert.assertEquals(itr.hasNext(), false);
   }
 


### PR DESCRIPTION
These changes makes the typical routine during dimension-filtered queries -- intersection of two concise bitsets and then iteration over them -- 1.5 to 4.5 times faster (depending on the % of one bits in the bitsets) and allocate less garbage.

I'll commit benchmarks to the main Druid repo later (since extendedset is going to be merged into Druid).

And I suspect that the intersection and iteration over concise bitsets could take the major part of time taken by slow queries. It is not visible through "average" and "sum" statistics, but I've seen "Max" of 34..something for "query/timeNs" and "32..something" for "query/bitmapIntersectionTimeNs".

Please review commit by commit, I've tried to keep them small.