### PR TITLE
Fix incorrect union and intersection optimizations

### DIFF
--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
@@ -345,7 +345,7 @@ public class ImmutableConciseSet
     // Use PriorityQueue, because sometimes as much as 20k of bitsets are unified, and the asymptotic complexity of
     // keeping bitsets in a sorted array (n^2), as in doIntersection(), becomes more important factor than PriorityQueue
     // inefficiency.
-    PriorityQueue<WordIterator> theQ = new PriorityQueue<>(UNION_COMPARATOR);
+    PriorityQueue<WordIterator> theQ = new PriorityQueue<WordIterator>(UNION_COMPARATOR);
 
     // populate priority queue
     while (sets.hasNext()) {

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
@@ -345,7 +345,8 @@ public class ImmutableConciseSet
     // Use PriorityQueue, because sometimes as much as 20k of bitsets are unified, and the asymptotic complexity of
     // keeping bitsets in a sorted array (n^2), as in doIntersection(), becomes more important factor than PriorityQueue
     // inefficiency.
-    PriorityQueue<WordIterator> theQ = new PriorityQueue<WordIterator>(UNION_COMPARATOR);
+    // Need to specify initial capacity because JDK 7 doesn't have Comparator-only constructor of PriorityQueue
+    PriorityQueue<WordIterator> theQ = new PriorityQueue<>(11, UNION_COMPARATOR);
 
     // populate priority queue
     while (sets.hasNext()) {

--- a/src/test/java/it.uniroma3.mat.extendedset/intset/ImmutableConciseSetTest.java
+++ b/src/test/java/it.uniroma3.mat.extendedset/intset/ImmutableConciseSetTest.java
@@ -1097,6 +1097,33 @@ public class ImmutableConciseSetTest
     verifyUnion(expected, sets);
   }
 
+  @Test
+  public void testUnion23()
+  {
+    ConciseSet set1 = new ConciseSet();
+    set1.add(10);
+    set1.add(1000);
+
+    ConciseSet set2 = new ConciseSet();
+    for (int i = 0; i < 10; i++) {
+      set2.add(i);
+    }
+    for (int i = 11; i < 1000; i++) {
+      set2.add(i);
+    }
+
+    List<ImmutableConciseSet> sets = Arrays.asList(
+        ImmutableConciseSet.compact(ImmutableConciseSet.newImmutableFromMutable(set1)),
+        ImmutableConciseSet.compact(ImmutableConciseSet.newImmutableFromMutable(set2))
+    );
+    List<Integer> expected = new ArrayList<>();
+    for (int i = 0; i <= 1000; i++) {
+      expected.add(i);
+    }
+
+    verifyUnion(expected, sets);
+  }
+
   private void verifyUnion(List<Integer> expected, List<ImmutableConciseSet> sets)
   {
     List<Integer> actual = Lists.newArrayList();


### PR DESCRIPTION
It turned out that assumptions made in #10 are wrong in production. We do unions of up to 23k bitmaps and intersections of up to 31 bitmaps.

 - For unions, #10 is reverted, and now `PriorityQueue` is used again instead of sorted arrays.
 - For intersections, bubble sort is faster than insertion sort only for 2-3 bitmaps when intersecting 10 bitmaps it's already considerably slower, so I replaced bubble sort with partial insertion sort.

Here is complete comparison of this library with this PR (first line in every pair of lines) and *before* #10 (the second line). The last column shows how much the new version is faster than the old version.
```
Benchmark                                     (bitmapAlgo)  (n)  (prob)   (size)  Mode  Cnt           Score           Error  Units
BitmapIterationBenchmark.intersectionAndIter	concise	2	0	3000000	avgt	5	96.282	±	25.852	ns/op	0.4947577217
BitmapIterationBenchmark.intersectionAndIter	concise	2	0	3000000	avgt	5	190.566	±	10.3	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	2	0.001	3000000	avgt	5	2790574.065	±	94698.76	ns/op	0.7187229853
BitmapIterationBenchmark.intersectionAndIter	concise	2	0.001	3000000	avgt	5	9921088.178	±	245808.367	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	2	0.1	3000000	avgt	5	11492543.3	±	528964.618	ns/op	0.5441962861
BitmapIterationBenchmark.intersectionAndIter	concise	2	0.1	3000000	avgt	5	25213799.17	±	2221109.869	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	2	0.5	3000000	avgt	5	26159852.49	±	3125529.538	ns/op	0.3190738774
BitmapIterationBenchmark.intersectionAndIter	concise	2	0.5	3000000	avgt	5	38418048.04	±	2776325.362	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	2	0.99	3000000	avgt	5	12979064.84	±	353312.833	ns/op	0.4604157611
BitmapIterationBenchmark.intersectionAndIter	concise	2	0.99	3000000	avgt	5	24053824.97	±	1871626.614	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	2	1	3000000	avgt	5	9731776.891	±	311241.099	ns/op	0.2913300984
BitmapIterationBenchmark.intersectionAndIter	concise	2	1	3000000	avgt	5	13732454.09	±	796930.449	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	10	0	3000000	avgt	5	516.418	±	97.398	ns/op	0.4745334663
BitmapIterationBenchmark.intersectionAndIter	concise	10	0	3000000	avgt	5	982.78	±	130.154	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	10	0.001	3000000	avgt	5	11838903.87	±	844090.447	ns/op	0.8719773588
BitmapIterationBenchmark.intersectionAndIter	concise	10	0.001	3000000	avgt	5	92475079.14	±	17678677.66	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	10	0.1	3000000	avgt	5	21147441.69	±	862846.341	ns/op	0.7822884852
BitmapIterationBenchmark.intersectionAndIter	concise	10	0.1	3000000	avgt	5	97135154.76	±	6599409.129	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	10	0.5	3000000	avgt	5	36859660.37	±	942576.134	ns/op	0.7065239074
BitmapIterationBenchmark.intersectionAndIter	concise	10	0.5	3000000	avgt	5	125596807.7	±	7890860.123	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	10	0.99	3000000	avgt	5	17889046.61	±	745207.982	ns/op	0.6509732931
BitmapIterationBenchmark.intersectionAndIter	concise	10	0.99	3000000	avgt	5	51254091.05	±	7926597.112	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	10	1	3000000	avgt	5	9709009.643	±	458113.304	ns/op	0.3231533574
BitmapIterationBenchmark.intersectionAndIter	concise	10	1	3000000	avgt	5	14344474.85	±	533078.817	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	100	0	3000000	avgt	5	5071.834	±	371.558	ns/op	0.5020439252
BitmapIterationBenchmark.intersectionAndIter	concise	100	0	3000000	avgt	5	10185.304	±	872.669	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	100	0.001	3000000	avgt	5	246237784.6	±	24723226.65	ns/op	0.8829329863
BitmapIterationBenchmark.intersectionAndIter	concise	100	0.001	3000000	avgt	5	2103391697	±	111666452.8	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	100	0.1	3000000	avgt	5	638098730.2	±	14080039.23	ns/op	0.690406983
BitmapIterationBenchmark.intersectionAndIter	concise	100	0.1	3000000	avgt	5	2061088898	±	57765995.12	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	100	0.5	3000000	avgt	5	399298480.9	±	36467722.38	ns/op	0.6454549299
BitmapIterationBenchmark.intersectionAndIter	concise	100	0.5	3000000	avgt	5	1126227706	±	262999745.6	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	100	0.99	3000000	avgt	5	19840835.74	±	809282.162	ns/op	0.3681974046
BitmapIterationBenchmark.intersectionAndIter	concise	100	0.99	3000000	avgt	5	31403536.31	±	2424473.7	ns/op	
BitmapIterationBenchmark.intersectionAndIter	concise	100	1	3000000	avgt	5	9506523.105	±	1048774.891	ns/op	0.3540264647
BitmapIterationBenchmark.intersectionAndIter	concise	100	1	3000000	avgt	5	14716582.93	±	1212686.587	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	2	0	3000000	avgt	5	48.568	±	2.364	ns/op	0.4692079868
BitmapIterationBenchmark.unionAndIter	concise	2	0	3000000	avgt	5	91.501	±	20.234	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	2	0.001	3000000	avgt	5	11444706.01	±	929922.872	ns/op	0.3951695661
BitmapIterationBenchmark.unionAndIter	concise	2	0.001	3000000	avgt	5	18922172.85	±	375687.975	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	2	0.1	3000000	avgt	5	23045005.89	±	4344988.849	ns/op	0.2588213389
BitmapIterationBenchmark.unionAndIter	concise	2	0.1	3000000	avgt	5	31092376.37	±	1201951.844	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	2	0.5	3000000	avgt	5	29139393.31	±	1564076.763	ns/op	0.1825057731
BitmapIterationBenchmark.unionAndIter	concise	2	0.5	3000000	avgt	5	35644769.53	±	1302338.625	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	2	0.99	3000000	avgt	5	20594114.99	±	1086667.159	ns/op	0.1544129879
BitmapIterationBenchmark.unionAndIter	concise	2	0.99	3000000	avgt	5	24354814.7	±	2800806.864	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	2	1	3000000	avgt	5	16074010.71	±	3723286.231	ns/op	0.3843908291
BitmapIterationBenchmark.unionAndIter	concise	2	1	3000000	avgt	5	26110739.52	±	10166077.31	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	10	0	3000000	avgt	5	62.445	±	5.671	ns/op	0.5688631437
BitmapIterationBenchmark.unionAndIter	concise	10	0	3000000	avgt	5	144.838	±	67.287	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	10	0.001	3000000	avgt	5	70031494.27	±	2701103.419	ns/op	0.4967361303
BitmapIterationBenchmark.unionAndIter	concise	10	0.001	3000000	avgt	5	139154623.4	±	19699930.27	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	10	0.1	3000000	avgt	5	59745577.16	±	2096786.454	ns/op	0.534121576
BitmapIterationBenchmark.unionAndIter	concise	10	0.1	3000000	avgt	5	128242850.7	±	23607615.47	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	10	0.5	3000000	avgt	5	57402956.26	±	4565723.626	ns/op	0.5597717559
BitmapIterationBenchmark.unionAndIter	concise	10	0.5	3000000	avgt	5	130393624.3	±	7783543.781	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	10	0.99	3000000	avgt	5	45550719.29	±	3181814.282	ns/op	0.6025642531
BitmapIterationBenchmark.unionAndIter	concise	10	0.99	3000000	avgt	5	114611530.7	±	6838960.714	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	10	1	3000000	avgt	5	43720854.25	±	1910292.965	ns/op	0.6250106301
BitmapIterationBenchmark.unionAndIter	concise	10	1	3000000	avgt	5	116592249.7	±	30553823.92	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	100	0	3000000	avgt	5	233.497	±	18.234	ns/op	0.1354076411
BitmapIterationBenchmark.unionAndIter	concise	100	0	3000000	avgt	5	270.066	±	21.06	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	100	0.001	3000000	avgt	5	743282267.6	±	187414640.9	ns/op	0.4397165483
BitmapIterationBenchmark.unionAndIter	concise	100	0.001	3000000	avgt	5	1326618277	±	115446383.1	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	100	0.1	3000000	avgt	5	745564441.6	±	21932447.41	ns/op	0.4764168385
BitmapIterationBenchmark.unionAndIter	concise	100	0.1	3000000	avgt	5	1423965659	±	70898471.22	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	100	0.5	3000000	avgt	5	754418666.3	±	65546078.26	ns/op	0.4657921658
BitmapIterationBenchmark.unionAndIter	concise	100	0.5	3000000	avgt	5	1412219399	±	105685505.3	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	100	0.99	3000000	avgt	5	752671429.4	±	19678532.05	ns/op	0.4597950914
BitmapIterationBenchmark.unionAndIter	concise	100	0.99	3000000	avgt	5	1393307275	±	61921358.62	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	100	1	3000000	avgt	5	742090665.7	±	39243223.77	ns/op	0.4808327013
BitmapIterationBenchmark.unionAndIter	concise	100	1	3000000	avgt	5	1429386380	±	144658415.8	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	1000	0	3000000	avgt	5	2062.397	±	142.231	ns/op	0.004842137161
BitmapIterationBenchmark.unionAndIter	concise	1000	0	3000000	avgt	5	2072.432	±	210.156	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	1000	0.001	3000000	avgt	5	1536857959	±	212840516.8	ns/op	0.4705765189
BitmapIterationBenchmark.unionAndIter	concise	1000	0.001	3000000	avgt	5	2902889679	±	245372925.3	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	1000	0.1	3000000	avgt	5	1257321776	±	65222195.66	ns/op	0.5433247376
BitmapIterationBenchmark.unionAndIter	concise	1000	0.1	3000000	avgt	5	2753207541	±	400811144.5	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	1000	0.5	3000000	avgt	5	1288382450	±	274935910.1	ns/op	0.3724238193
BitmapIterationBenchmark.unionAndIter	concise	1000	0.5	3000000	avgt	5	2052949888	±	56558347.33	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	1000	0.99	3000000	avgt	5	1250968218	±	66077308.59	ns/op	0.536104864
BitmapIterationBenchmark.unionAndIter	concise	1000	0.99	3000000	avgt	5	2696661640	±	158328914.7	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	1000	1	3000000	avgt	5	1264489285	±	104170907.2	ns/op	0.4293556876
BitmapIterationBenchmark.unionAndIter	concise	1000	1	3000000	avgt	5	2215897465	±	113662124.1	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	22000	0	3000000	avgt	5	283148.942	±	15277.886	ns/op	0.01093650868
BitmapIterationBenchmark.unionAndIter	concise	22000	0	3000000	avgt	5	286279.844	±	14754.082	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	22000	0.001	3000000	avgt	5	1920929735	±	80734893.31	ns/op	0.5606549397
BitmapIterationBenchmark.unionAndIter	concise	22000	0.001	3000000	avgt	5	4372257500	±	567351286.3	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	22000	0.1	3000000	avgt	5	1952329186	±	162497870.5	ns/op	0.5474435505
BitmapIterationBenchmark.unionAndIter	concise	22000	0.1	3000000	avgt	5	4314001464	±	556729154.3	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	22000	0.5	3000000	avgt	5	1877950846	±	218209579.6	ns/op	0.5951652247
BitmapIterationBenchmark.unionAndIter	concise	22000	0.5	3000000	avgt	5	4638808127	±	1939106970	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	22000	0.99	3000000	avgt	5	1867989722	±	81404747.3	ns/op	0.6254654759
BitmapIterationBenchmark.unionAndIter	concise	22000	0.99	3000000	avgt	5	4987496751	±	960838077.1	ns/op	
BitmapIterationBenchmark.unionAndIter	concise	22000	1	3000000	avgt	5	1941514545	±	95214416.02	ns/op	0.5704701475
BitmapIterationBenchmark.unionAndIter	concise	22000	1	3000000	avgt	5	4520092220	±	137679492	ns/op	
```