### PR TITLE
Remove volatile modifier from ImmutableConciseSet.WordIterator.hasNextWord and ConciseSet.modCount fields

### DIFF
--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ConciseSet.java
@@ -114,7 +114,7 @@ public class ConciseSet extends AbstractIntSet implements java.io.Serializable
    * User for <i>fail-fast</i> iterator. It counts the number of operations
    * that <i>do</i> modify {@link #words}
    */
-  protected transient volatile int modCount = 0;
+  protected transient int modCount = 0;
 
   /**
    * Resets to an empty set

--- a/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
+++ b/src/main/java/it/uniroma3/mat/extendedset/intset/ImmutableConciseSet.java
@@ -1128,7 +1128,7 @@ public class ImmutableConciseSet
     // but this is uncertain
     int word;
 
-    private volatile boolean hasNextWord = false;
+    private boolean hasNextWord = false;
 
     WordIterator()
     {


### PR DESCRIPTION
None of the classes from `it.uniroma3.mat.extendedset.intset` package are designed for concurrent access, those volatiles are harmful for performance and misleading for readers.